### PR TITLE
fix: ct info pulls data from template instead of labels

### DIFF
--- a/src/folder.view/usr/local/emhttp/plugins/folder.view/server/lib.php
+++ b/src/folder.view/usr/local/emhttp/plugins/folder.view/server/lib.php
@@ -111,7 +111,7 @@
                     return $el['image'] == $ct['info']['Config']['Image'] && $el['Name'] == $ct['info']['Name'];
                 });
                 $template = $template[array_key_first($template)];
-                if(!is_null($template)) {
+                if($ct['Labels']['net.unraid.docker.managed'] == 'dockerman' && !is_null($template)) {
                     $ct['info']['State']['WebUi'] = $template['WebUi'];
                     $ct['info']['registry'] = $template['registry'];
                     $ct['info']['Support'] = $template['Support'];


### PR DESCRIPTION
It seems that if there's an old template in unRaid, this plugin gets its ct.info from there instead of from labels, regardless of if it's a dockerman container or not.
unRaid get's it's link info correcly so the container menu has correct link.  Folder View doesn't so it sends you to a blank page.
This PR should fix it.