### PR TITLE
feat: update css to better support long lists

### DIFF
--- a/src/folder.view/usr/local/emhttp/plugins/folder.view/styles/docker.css
+++ b/src/folder.view/usr/local/emhttp/plugins/folder.view/styles/docker.css
@@ -33,8 +33,9 @@
 }
 
 .folder-preview {
+    margin: 2px
     border-radius: 4px;
-    height: 3.5em;
+    height: auto;
     overflow: hidden;
     display: flex;
     flex-wrap: wrap;
@@ -44,8 +45,7 @@
 .folder-preview-wrapper {
     float: left;
     height: 100%;
-    margin-left: 10px;
-    margin-top: 7px;
+    margin: 10px;
 }
 
 .folder-preview-wrapper .inner > span.appname {


### PR DESCRIPTION
Currently, if you have long lists it'll not show all the docker containers
![chrome_5v2z9IELMg](https://github.com/scolcipitato/folder.view/assets/55490546/7502932d-4dc6-4c43-9299-1a7d4b0b1ea4)

Setting height to auto allows it to stack, the the other change is to make it look better once stacked
![chrome_H5GcU9fzsW](https://github.com/scolcipitato/folder.view/assets/55490546/ca130f2f-fd4b-434d-82b5-d99415c7135e)
